### PR TITLE
Updated Animation & Transition duration

### DIFF
--- a/Assets/Prefabs/characters/Basic Shooter Pack/Exo Gray.controller
+++ b/Assets/Prefabs/characters/Basic Shooter Pack/Exo Gray.controller
@@ -26,9 +26,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.90384614
+  m_TransitionDuration: 1.13983
+  m_TransitionOffset: 0.007822674
+  m_ExitTime: 0.014016202
   m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -299,9 +299,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25000006
-  m_TransitionOffset: 0.18562867
-  m_ExitTime: 0.6590909
+  m_TransitionDuration: 0.000000015239824
+  m_TransitionOffset: 0.055967785
+  m_ExitTime: 0.082819626
   m_HasExitTime: 0
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
@@ -399,11 +399,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.33427492
+  m_TransitionDuration: 0.14026067
   m_TransitionOffset: 0
-  m_ExitTime: 0.08834108
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_ExitTime: 0.066783935
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -421,11 +421,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
-  m_TransitionOffset: 0
-  m_ExitTime: 0.90384614
+  m_TransitionDuration: 0.44058377
+  m_TransitionOffset: 0.9804826
+  m_ExitTime: 0.37540925
   m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1

--- a/Assets/Prefabs/characters/Basic Shooter Pack/Exo Gray@Hit Reaction.fbx.meta
+++ b/Assets/Prefabs/characters/Basic Shooter Pack/Exo Gray@Hit Reaction.fbx.meta
@@ -37,7 +37,7 @@ ModelImporter:
       takeName: mixamo.com
       internalID: -203655887218126122
       firstFrame: 0
-      lastFrame: 50
+      lastFrame: 30
       wrapMode: 0
       orientationOffsetY: 0
       level: 0


### PR DESCRIPTION
Play-testing revealed that the playerHit animation and transitions was taking too long (~2 secs), making the game unnecessarily difficult to play. 
This commit is a last-minute fix to address this. PlayerHit animation & transition reduced to 0.5 secs